### PR TITLE
Minor changes to Lucene Indexing Engine

### DIFF
--- a/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/LuceneDataFormat.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/LuceneDataFormat.java
@@ -39,7 +39,11 @@ public class LuceneDataFormat extends DataFormat {
         ),
         new FieldTypeCapabilities(
             "keyword",
-            Set.of(FieldTypeCapabilities.Capability.FULL_TEXT_SEARCH, FieldTypeCapabilities.Capability.STORED_FIELDS)
+            Set.of(FieldTypeCapabilities.Capability.COLUMNAR_STORAGE, FieldTypeCapabilities.Capability.STORED_FIELDS)
+        ),
+        new FieldTypeCapabilities(
+            "match_only_text",
+            Set.of(FieldTypeCapabilities.Capability.FULL_TEXT_SEARCH)
         )
     );
 

--- a/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/index/LuceneDocumentInput.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/index/LuceneDocumentInput.java
@@ -14,6 +14,7 @@ import org.opensearch.be.lucene.LuceneFieldFactory;
 import org.opensearch.be.lucene.LuceneFieldFactoryRegistry;
 import org.opensearch.common.annotation.ExperimentalApi;
 import org.opensearch.index.engine.dataformat.DocumentInput;
+import org.opensearch.index.engine.dataformat.DocumentInput;
 import org.opensearch.index.mapper.MappedFieldType;
 
 /**
@@ -34,8 +35,12 @@ import org.opensearch.index.mapper.MappedFieldType;
 @ExperimentalApi
 public class LuceneDocumentInput implements DocumentInput<Document> {
 
-    /** Name of the row ID field stored in each Lucene document. */
-    public static final String ROW_ID_FIELD = "__row_id__";
+    /**
+     * Name of the row ID field stored in each Lucene document.
+     * @deprecated Use {@link DocumentInput#ROW_ID_FIELD} instead.
+     */
+    @Deprecated
+    public static final String ROW_ID_FIELD = DocumentInput.ROW_ID_FIELD;
 
     private final Document document;
     private final LuceneFieldFactoryRegistry fieldFactoryRegistry;

--- a/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/index/LuceneIndexingExecutionEngine.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/index/LuceneIndexingExecutionEngine.java
@@ -22,6 +22,7 @@ import org.apache.lucene.misc.store.HardlinkCopyDirectoryWrapper;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.MMapDirectory;
 import org.opensearch.be.lucene.LuceneDataFormat;
+import org.opensearch.be.lucene.LuceneFieldFactoryRegistry;
 import org.opensearch.common.annotation.ExperimentalApi;
 import org.opensearch.index.engine.dataformat.DataFormat;
 import org.opensearch.index.engine.dataformat.IndexingExecutionEngine;
@@ -77,6 +78,7 @@ public class LuceneIndexingExecutionEngine implements IndexingExecutionEngine<Lu
     private final Path baseDirectory;
     private final Analyzer analyzer;
     private final Codec codec;
+    private final LuceneFieldFactoryRegistry fieldFactoryRegistry;
 
     /**
      * Creates a new LuceneIndexingExecutionEngine with a specific analyzer.
@@ -100,12 +102,13 @@ public class LuceneIndexingExecutionEngine implements IndexingExecutionEngine<Lu
         this.baseDirectory = store.shardPath().resolve(LuceneDataFormat.LUCENE_FORMAT_NAME);
         this.analyzer = sharedWriter.getAnalyzer();
         this.codec = sharedWriter.getConfig().getCodec();
+        this.fieldFactoryRegistry = new LuceneFieldFactoryRegistry();
 
         // Create the lucene subdirectory if it doesn't exist
         try {
             Files.createDirectories(baseDirectory);
         } catch (FileAlreadyExistsException ex) {
-            logger.warn("Directory already exists: {}", store.shardPath().resolve("parquet"));
+            logger.warn("Directory already exists: {}", baseDirectory);
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
@@ -147,6 +150,7 @@ public class LuceneIndexingExecutionEngine implements IndexingExecutionEngine<Lu
      */
     @Override
     public Writer<LuceneDocumentInput> createWriter(long writerGeneration) {
+        assert sharedWriter.isOpen() : "Cannot create writer — shared IndexWriter is closed";
         try {
             return new LuceneWriter(writerGeneration, dataFormat, baseDirectory, analyzer, codec);
         } catch (IOException e) {
@@ -161,7 +165,7 @@ public class LuceneIndexingExecutionEngine implements IndexingExecutionEngine<Lu
      */
     @Override
     public LuceneDocumentInput newDocumentInput() {
-        return new LuceneDocumentInput();
+        return new LuceneDocumentInput(fieldFactoryRegistry);
     }
 
     /** {@inheritDoc} Returns the {@link LuceneDataFormat} descriptor. */

--- a/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/index/LuceneWriter.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/index/LuceneWriter.java
@@ -116,6 +116,14 @@ public class LuceneWriter implements Writer<LuceneDocumentInput> {
     @Override
     public WriteResult addDoc(LuceneDocumentInput input) throws IOException {
         Document doc = input.getFinalInput();
+        assert doc.getField(LuceneDocumentInput.ROW_ID_FIELD) != null : "Document missing required "
+            + LuceneDocumentInput.ROW_ID_FIELD
+            + " field at doc position "
+            + docCount;
+        assert doc.getField(LuceneDocumentInput.ROW_ID_FIELD).numericValue().longValue() == docCount : "Row ID mismatch: expected "
+            + docCount
+            + " but got "
+            + doc.getField(LuceneDocumentInput.ROW_ID_FIELD).numericValue().longValue();
         indexWriter.addDocument(doc);
         long currentDocId = docCount;
         docCount++;
@@ -220,12 +228,12 @@ public class LuceneWriter implements Writer<LuceneDocumentInput> {
                 indexWriter.rollback();
             }
         } catch (Exception e) {
-            // Best effort — may already be closed
+            logger.warn("Failed to rollback IndexWriter for generation {}", writerGeneration, e);
         }
         try {
             directory.close();
         } catch (Exception e) {
-            // Best effort — may already be closed
+            logger.warn("Failed to close directory for generation {}", writerGeneration, e);
         }
         IOUtils.rm(tempDirectory);
     }

--- a/sandbox/plugins/composite-engine/src/main/java/org/opensearch/composite/CompositeWriter.java
+++ b/sandbox/plugins/composite-engine/src/main/java/org/opensearch/composite/CompositeWriter.java
@@ -105,7 +105,7 @@ class CompositeWriter implements Writer<CompositeDocumentInput>, Lockable {
             throw new IllegalStateException("Cannot add document to writer in state " + state.get());
         }
         // Write to primary first
-        doc.setRowId("__row_id__", rowIdGenerator.currentRowId());
+        doc.setRowId(DocumentInput.ROW_ID_FIELD, rowIdGenerator.currentRowId());
         WriteResult primaryResult = primaryWriter.addDoc(doc.getPrimaryInput());
         switch (primaryResult) {
             case WriteResult.Success s -> logger.trace("Successfully added document in primary format [{}]", primaryFormat.name());

--- a/server/src/main/java/org/opensearch/index/engine/dataformat/DocumentInput.java
+++ b/server/src/main/java/org/opensearch/index/engine/dataformat/DocumentInput.java
@@ -20,6 +20,10 @@ import org.opensearch.index.mapper.MappedFieldType;
  */
 @ExperimentalApi
 public interface DocumentInput<T> extends AutoCloseable {
+
+    /** Standard field name for the row ID used to correlate documents across data formats. */
+    String ROW_ID_FIELD = "__row_id__";
+
     /**
      * Gets the final input representation.
      *


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Minor improvements to the PR

LuceneIndexingExecutionEngine.java — shared field factory registry instead of per-document allocation, fixed copy-paste log message ("parquet" → actual path), added assertions for shared writer open state, duplicate generation detection, and freshly incorporated segment invariants (numDocs > 0, delCount == 0).

LuceneDataFormat.java — changed keyword capability from FULL_TEXT_SEARCH to COLUMNAR_STORAGE, added match_only_text to supportedFields().

LuceneWriter.java — close() now logs exceptions instead of silently swallowing them. addDoc() asserts row ID field presence and value correctness per document.

DocumentInput.java — added ROW_ID_FIELD constant as the canonical cross-format row ID field name.

### Related Issues
Resolves # https://github.com/opensearch-project/OpenSearch/pull/21299/
<!-- List any other related issues here -->

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
